### PR TITLE
[INVE-13771] Dep check support backports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-siren",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin",
-  "version": "2.0.0",
+  "name": "eslint-plugin-siren",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-siren",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Provides custom eslint rules developed by Siren",
   "main": "index.js",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/rules/same-core-dependency-version/same-core-dependency-version.js
+++ b/rules/same-core-dependency-version/same-core-dependency-version.js
@@ -46,9 +46,6 @@ module.exports = {
     options.ignore = options.ignore || [];
     options.coreBranch = options.coreBranch || process.env.CHANGE_TARGET || 'master';
 
-    console.log('#############################')
-    console.log(options);
-    console.log('#############################')
     const coreDependencies = getCoreDependencies(options.coreBranch, process.env.GITHUB_TOKEN);
 
     for (const [dependency, version] of Object.entries(packageJson.dependencies)) {

--- a/rules/same-core-dependency-version/same-core-dependency-version.js
+++ b/rules/same-core-dependency-version/same-core-dependency-version.js
@@ -21,12 +21,10 @@ module.exports = {
             type: 'array',
             items: {
               type: 'string'
-            },
-            default: []
+            }
           },
           coreBranch: {
-            type: 'string',
-            default: 'master'
+            type: 'string'
           }
         }
       }
@@ -44,14 +42,17 @@ module.exports = {
       return {};
     }
 
-    const { ignore, coreBranch } = context.options[0] || { ignore: [], coreBranch: process.env.CHANGE_TARGET || 'master' };
+    const options = context.options[0] || {};
+    options.ignore = options.ignore || [];
+    options.coreBranch = options.coreBranch || process.env.CHANGE_TARGET || 'master';
+
     console.log('#############################')
-    console.log({ ignore, coreBranch });
+    console.log(options);
     console.log('#############################')
-    const coreDependencies = getCoreDependencies(coreBranch, process.env.GITHUB_TOKEN);
+    const coreDependencies = getCoreDependencies(options.coreBranch, process.env.GITHUB_TOKEN);
 
     for (const [dependency, version] of Object.entries(packageJson.dependencies)) {
-      if (!!coreDependencies[dependency] && coreDependencies[dependency] !== version && !ignore.includes(dependency)) {
+      if (!!coreDependencies[dependency] && coreDependencies[dependency] !== version && !options.ignore.includes(dependency)) {
         context.report({
           message: `Investigate core uses ${coreDependencies[dependency]}, but this repo uses ${version} of '${dependency}'`,
           loc: {


### PR DESCRIPTION
Add option to specify Investigate version to compare against or use `CHANGE_TARGET` environment variable if available (like in Jenkins).

The `scripting` repo was used to test in Jenkins.

[PR against master](https://github.com/sirensolutions/scripting/pull/176):
![image](https://user-images.githubusercontent.com/7104356/104051167-9d16b500-51df-11eb-84bb-8bb121b75dc6.png)

[PR against branch-11.0.x](https://github.com/sirensolutions/scripting/pull/177):
![image](https://user-images.githubusercontent.com/7104356/104051105-7eb0b980-51df-11eb-9504-bf1285acf4f2.png)
