### PR TITLE
[INVE-25446] Fix for binary expression as function arg for no-double-await rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-siren",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Provides custom eslint rules developed by Siren",
   "main": "index.js",
   "license": "MIT",

--- a/rules/no-double-await/no-double-await.js
+++ b/rules/no-double-await/no-double-await.js
@@ -182,7 +182,7 @@ function _addCallArgNames(context, nodes, arr) {
       }
     } else if (node.type === 'TemplateLiteral' && node.expressions) {
       _addCallArgNames(context, node.expressions, arr);
-    } else if (node.type === 'Literal' || node.type === 'ThisExpression' || node.type === 'BinaryExpression') {
+    } else if (node.type === 'Literal' || node.type === 'ThisExpression' || node.type === 'BinaryExpression' || node.type === 'UnaryExpression') {
       // Note:
       // do nothing as this would be things like true, false, 'string', 5, or this
     } else {

--- a/rules/no-double-await/no-double-await.js
+++ b/rules/no-double-await/no-double-await.js
@@ -182,7 +182,7 @@ function _addCallArgNames(context, nodes, arr) {
       }
     } else if (node.type === 'TemplateLiteral' && node.expressions) {
       _addCallArgNames(context, node.expressions, arr);
-    } else if (node.type === 'Literal' || node.type === 'ThisExpression') {
+    } else if (node.type === 'Literal' || node.type === 'ThisExpression' || node.type === 'BinaryExpression') {
       // Note:
       // do nothing as this would be things like true, false, 'string', 5, or this
     } else {

--- a/rules/no-double-await/no-double-await.test.js
+++ b/rules/no-double-await/no-double-await.test.js
@@ -145,7 +145,16 @@ ruleTester.run('no-double-await', rule, {
   ],
   invalid: [
     {
-      name: 'binary operation',
+      name: 'UnaryExpression  as function argument',
+      code: `
+      async function main() {
+        const x = await getX();
+        const y = await getY(!1);
+      }`,
+      errors
+    },
+    {
+      name: 'BinaryExpression as function argument',
       code: `
       async function main() {
         const x = await getX();

--- a/rules/no-double-await/no-double-await.test.js
+++ b/rules/no-double-await/no-double-await.test.js
@@ -145,6 +145,15 @@ ruleTester.run('no-double-await', rule, {
   ],
   invalid: [
     {
+      name: 'binary operation',
+      code: `
+      async function main() {
+        const x = await getX();
+        const y = await getY(1+2);
+      }`,
+      errors
+    },
+    {
       name: 'second line arg as variable',
       code : `
       async function main() {


### PR DESCRIPTION
Fixed added  unit test 

<img width="717" alt="Screenshot 2024-10-02 at 10 43 28" src="https://github.com/user-attachments/assets/bcca02f3-c7fb-49cf-8c91-3346b59292ca">


After this is merged will tag it and bump the version in kibi-internal 

